### PR TITLE
Really center page

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -1,5 +1,5 @@
 body {
-    padding-left: 50px;
+    margin: 0;
     font: 10pt "Courier New";
 }
 


### PR DESCRIPTION
Since the main page element is centered, there will automatically be padding on left and right; by removing the padding-left:50% rule from the css, the page now fits smaller display areas a little better (e.g. when the window is resized, it doesn't start overflowing to the right while still displaying some whitespace to the left, so it stays centered until there really is no option except starting to cut off the main area).

Also, made margins zero because even though they are applied by default on all sides equally, the browser starts cutting off on the right while the left margin stays there (i.e. the same thing as happens to the current padding setting).
