### PR TITLE
Use _blank instead of _new for link targets

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -46,7 +46,7 @@ function getNumUpdates() {
 
 function addUpdate(msg) {
   var lang = $('<span>').attr({'class': 'lang'}).text('[' + msg.wikipediaShort + ']');
-  var a = $('<a>').attr({'class': 'page', 'href': msg.url, 'title': msg.comment, target: '_new'}).text(msg.page);
+  var a = $('<a>').attr({'class': 'page', 'href': msg.url, 'title': msg.comment, target: '_blank'}).text(msg.page);
   var delta;
   if (msg.delta == null) delta = "n/a";
   else if (msg.delta < 0) delta = msg.delta;


### PR DESCRIPTION
> Target "_blank" is a reserved value which prompts the browser to create a new tab (or new window), and load the link question there.
> 
> Any other target value, including "_new", instructs the browser to seek a window with that internal ID ssigned to it (or create it if one doesn't exist yet), make it navigate to this link.
> 
> This means that when you've click a link, kept the tab open for further analsys and then go
> back to the stream and click another, surprise surprise, it overwrites the tab you kept with
> this new link.

I've confirmed this bug both in Firefox and in Chromium. See also <https://stackoverflow.com/a/8867079/319266>.